### PR TITLE
Enables editing of player and creature stats

### DIFF
--- a/src/2d6-dungeon-web-client/Components/Pages/Combat.razor
+++ b/src/2d6-dungeon-web-client/Components/Pages/Combat.razor
@@ -43,7 +43,7 @@ else{
 
         <FluentStack Orientation="Orientation.Horizontal" Width="100%">
             <FluentCard Width="600px"> 
-                <AdventurerCard Player="CombatState.Player" Extented=true></AdventurerCard>
+                <AdventurerCard Player="CombatState.Player" Extented=true Editable=true></AdventurerCard>
             </FluentCard>
             <FluentCard Width="400px">
                 <QuickReferenceCombatCard   TurnCounter="@CombatState.TurnCounter" 
@@ -51,7 +51,7 @@ else{
                 </QuickReferenceCombatCard>
             </FluentCard>
             <FluentCard Width="400px">
-                <CreatureCard creature="CombatState.Creature"></CreatureCard> 
+                <CreatureCard creature="CombatState.Creature" Editable=true></CreatureCard> 
             </FluentCard>
         </FluentStack>
         <CombatJournal actions="CombatState.CombatActions" ></CombatJournal>

--- a/src/2d6-dungeon-web-client/Components/Pages/Play.razor
+++ b/src/2d6-dungeon-web-client/Components/Pages/Play.razor
@@ -53,6 +53,7 @@
 
                         <FluentButton @onclick=RefreshCanvas Appearance="Appearance.Accent">Refresh Canvas</FluentButton>
 
+                        
                         <div style="width: 100px;">
                             <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center">
                                 <FluentButton @onclick="@( () => MoveRoom("LEFT"))" Appearance="Appearance.Accent" IconStart="@(new Icons.Regular.Size16.ArrowLeft())" />
@@ -63,7 +64,7 @@
                                 <FluentButton @onclick="@( () => MoveRoom("RIGHT"))" Appearance="Appearance.Accent" IconStart="@(new Icons.Regular.Size16.ArrowRight())" />
                             </FluentStack> 
                         </div>
-    
+                        <FluentLabel Color="@Color.Disabled">Once you have a new room, position it using the arrows above, then pin it to the map with the button below.</FluentLabel>
                         <FluentButton @onclick=AddRoomToDungeon Appearance="Appearance.Accent" IconStart="@(new Icons.Regular.Size16.LocationAdd())" /> 
 
                     </FluentStack>

--- a/src/2d6-dungeon-web-client/Components/Shared/AdventurerCard.razor
+++ b/src/2d6-dungeon-web-client/Components/Shared/AdventurerCard.razor
@@ -11,16 +11,24 @@
                 OnClick="@(() => ToggleExtended())">
         <FluentStack Orientation="Orientation.Vertical" VerticalGap="0">
             <FluentLabel Typo="Typography.H3">@Player.Name</FluentLabel>
-            <FluentLabel Typo="Typography.Body"><b>XP:</b> @Player.XP.ToString()</FluentLabel>
-            <FluentLabel Typo="Typography.Body"><b>Level:</b> @Player.Level.ToString()</FluentLabel>
+            <FluentLabel Typo="Typography.Body"><b>XP:</b><FluentNumberField @bind-Value="@Player.XP" style="width: 80px;" /></FluentLabel>
+            <FluentLabel Typo="Typography.Body"><b>Level:</b> <FluentNumberField @bind-Value="@Player.Level" style="width: 80px;" /></FluentLabel>
         </FluentStack>
 </FluentPersona>
 @if(Extented)
 {
     <FluentStack Orientation="Orientation.Vertical" VerticalGap="5" Width="100%">
         <div>
-            <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="5" Width="100%">
-                <span class="sheetTitle">HP</span> @Player.HealthPoints.ToString()
+            <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Bottom" HorizontalGap="5" Width="100%">
+                @if(Editable)
+                {
+                    <span class="sheetTitle">HP</span> <FluentNumberField @bind-Value="@Player.HealthPoints" style="width: 80px;" />
+                }
+                else 
+                {
+                    <span class="sheetTitle">HP</span> @Player.HealthPoints.ToString()
+                }
+                    
                 <span class="sheetTitle">SH </span> @Player.Shift.ToString()
                 <span><span class="sheetTitle">Precision</span> @Player.Precision.ToString()</span>
             </FluentStack>
@@ -47,6 +55,9 @@
 
     [Parameter]
     public bool Extented { get; set; } = false;
+
+    [Parameter]
+    public bool Editable { get; set; } = false;
 
     private void ToggleExtended()
     {

--- a/src/2d6-dungeon-web-client/Components/Shared/CreatureCard.razor
+++ b/src/2d6-dungeon-web-client/Components/Shared/CreatureCard.razor
@@ -12,7 +12,14 @@
     <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="5">
         <div>
             <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="5">
-                <span><b>HP:</b> @creature.health_points</span>
+                @if(Editable)
+                {
+                    <span><b>HP:</b> <FluentNumberField @bind-Value=creature.health_points style="width: 70px;"/></span>
+                }
+                else 
+                {
+                    <span><b>HP:</b> @creature.health_points</span>
+                }
                 <span><b>XP:</b> @creature.experience.ToString()</span>
                 <span><b>SH:</b> @creature.shift_points.ToString()</span>
             </FluentStack>
@@ -55,6 +62,8 @@
     [Parameter] 
     public EventCallback<Creature> creatureChanged { get; set; }
 
+    [Parameter]
+    public bool Editable { get; set; } = false;
 
 
 


### PR DESCRIPTION
Allows modification of player and creature health points, XP, and level directly within the combat page.

Adds a new Editable parameter to the AdventurerCard and CreatureCard components, controlling the visibility of editable number fields for these statistics.

Improves the Play page with help text to guide users on the process of positioning new rooms.

fix #83 
