### PR TITLE
Change the way doors are draw

### DIFF
--- a/src/2d6-dungeon-web-client/Domain/MapTools.cs
+++ b/src/2d6-dungeon-web-client/Domain/MapTools.cs
@@ -33,19 +33,19 @@ public static class MapTools
             {
                 case Direction.North:
                     x = currentRoom.CoordX + door.Value.PositionOnWall;
-                    y = currentRoom.CoordY;
+                    y = currentRoom.CoordY - 1; // Position outside the room (above)
                     break;
                 case Direction.East:
-                    x = currentRoom.CoordX + currentRoom.Width;
+                    x = currentRoom.CoordX + currentRoom.Width; // Position outside the room (to the right)
                     y = currentRoom.CoordY + door.Value.PositionOnWall;
                     break;
                 case Direction.South:
                     x = currentRoom.CoordX + door.Value.PositionOnWall;
-                    y = currentRoom.CoordY + currentRoom.Height;
+                    y = currentRoom.CoordY + currentRoom.Height; // Position outside the room (below)
                     isMain = currentRoom.IsLobby;
                     break;
                 case Direction.West:
-                    x = currentRoom.CoordX;
+                    x = currentRoom.CoordX - 1; // Position outside the room (to the left)
                     y = currentRoom.CoordY + door.Value.PositionOnWall;
                     break;
             }

--- a/src/2d6-dungeon-web-client/wwwroot/scripts/canvasTools.js
+++ b/src/2d6-dungeon-web-client/wwwroot/scripts/canvasTools.js
@@ -81,31 +81,21 @@ function DrawDoor(posX, posY, orientation, isMain=false){
     doorColor = '#DEC5C0'
   }
 
+  // Always draw a full square (30x30)
+  let doorWidth = cubeSize; // one square
+  let doorHeight = cubeSize; // one square
+  
+  posX = posX * cubeSize;
+  posY = posY * cubeSize;
 
-  if(orientation == "H"){
-    let doorWith = 30; // one square
-    let doorHeight = 10;
-    posX = (posX - 1) * cubeSize;
-    posY = (posY * cubeSize) - 5;
-
-    context.fillStyle = '#000000'; 
-    context.fillRect(posX, posY, doorWith, doorHeight);
-    context.stroke();
-    context.fillStyle = doorColor;
-    context.fillRect(posX+1, posY+1, doorWith-2, doorHeight-2);
-    context.stroke();
+  if(orientation == 'V') {
+    posY = posY - cubeSize;
   }
-  else{
-    let doorWith = 10; 
-    let doorHeight = 30;// one square
-    posX = (posX * cubeSize) - 5;
-    posY = (posY - 1) * cubeSize;
 
-    context.fillStyle = '#000000'; 
-    context.fillRect(posX, posY, doorWith, doorHeight);
-    context.stroke();
-    context.fillStyle = doorColor;
-    context.fillRect(posX+1, posY+1, doorWith-2, doorHeight-2);
-    context.stroke();
-  }
+  context.fillStyle = '#000000'; 
+  context.fillRect(posX, posY, doorWidth, doorHeight);
+  context.stroke();
+  context.fillStyle = doorColor;
+  context.fillRect(posX+1, posY+1, doorWidth-2, doorHeight-2);
+  context.stroke();
 }


### PR DESCRIPTION
Adjusts the positioning of doors on the map to ensure they are placed outside the adjacent room's boundary.

Simplifies door drawing logic, ensuring doors are consistently drawn as full squares.
