### PR TITLE
Enables adventure deletion and fixes save count

### DIFF
--- a/src/.idea/.idea.2d6-dungeon-client/.idea/.gitignore
+++ b/src/.idea/.idea.2d6-dungeon-client/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/projectSettingsUpdater.xml
+/modules.xml
+/.idea.2d6-dungeon-client.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/src/.idea/.idea.2d6-dungeon-client/.idea/.name
+++ b/src/.idea/.idea.2d6-dungeon-client/.idea/.name
@@ -1,0 +1,1 @@
+2d6-dungeon-client

--- a/src/.idea/.idea.2d6-dungeon-client/.idea/indexLayout.xml
+++ b/src/.idea/.idea.2d6-dungeon-client/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/src/.idea/.idea.2d6-dungeon-client/.idea/vcs.xml
+++ b/src/.idea/.idea.2d6-dungeon-client/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/src/2d6-dungeon-service/Services/D6Service.cs
+++ b/src/2d6-dungeon-service/Services/D6Service.cs
@@ -28,8 +28,8 @@ public class D6Service
 
     public async Task<int> GetSaveGameCount()
     {
-        //todo: implement a save game in the database. 
-        return await Task.FromResult<int>(1);
+        var games = await GetAdventurePreviews();
+        return games?.value?.Count() ?? 0;
     }
 
     public async Task<AdventurePreviewList?> GetAdventurePreviews()

--- a/src/2d6-dungeon-service/Services/D6Service.cs
+++ b/src/2d6-dungeon-service/Services/D6Service.cs
@@ -82,6 +82,16 @@ public class D6Service
         
         return game;
     }
+    
+    public async Task<bool> AdventureDelete(int id)
+    {
+        var response = await httpClient.DeleteAsync($"api/adventure/id/{id.ToString()}");
+        var status = response.EnsureSuccessStatusCode();
+
+        if (status.IsSuccessStatusCode)
+            return true;
+        return false;
+    }
 
     #endregion
 

--- a/src/2d6-dungeon-service/Services/ID6Service.cs
+++ b/src/2d6-dungeon-service/Services/ID6Service.cs
@@ -10,6 +10,7 @@ public interface ID6Service
     Task<AdventurePreviewList?> GetAdventurePreviews();
     Task<Adventure> GetAdventure(int id);
     Task<Adventure> AdventureSave(Adventure game);
+    Task<bool> AdventureDelete(int id);
 
     // Adventurer
     Task<AdventurerPreviewList?> GetAdventurerPreviews();

--- a/src/2d6-dungeon-web-client/Components/Dialogues/NewRoomDialog.razor
+++ b/src/2d6-dungeon-web-client/Components/Dialogues/NewRoomDialog.razor
@@ -25,8 +25,8 @@
                 <div style="padding:20px;">
                     @if(sizeDiceResult != null)
                     {
-                        <Dice  face="@sizeDiceResult.PrimaryDice" size="Dice .DiceSize.regular" color="Dice .DiceColor.red"></Dice >
-                        <Dice  face="@sizeDiceResult.SecondaryDice" size="Dice .DiceSize.regular" color="Dice .DiceColor.purple"></Dice >
+                        <Dice  face="@sizeDiceResult.PrimaryDice" size="Dice .DiceSize.regular" color="Dice .DiceColor.red"></Dice>
+                        <Dice  face="@sizeDiceResult.SecondaryDice" size="Dice .DiceSize.regular" color="Dice .DiceColor.purple"></Dice>
                     }
                 </div>
             </FluentStack>

--- a/src/2d6-dungeon-web-client/Components/Pages/Home.razor
+++ b/src/2d6-dungeon-web-client/Components/Pages/Home.razor
@@ -29,7 +29,7 @@
     {
         try{
             savedGames = await D6Service.GetSaveGameCount();
-            if(savedGames == 0){
+                if(savedGames == 0){
                 savedGamesTips = "It look like you don't have any game saved. You should start by creating a new game.";
             }
             else{

--- a/src/2d6-dungeon-web-client/Components/Shared/AdventurePicker.razor
+++ b/src/2d6-dungeon-web-client/Components/Shared/AdventurePicker.razor
@@ -14,11 +14,15 @@
                     ResizableColumns=true 
                     TGridItem="AdventurePreview" 
                     OnRowClick="@(async (args) => { if (args.Item?.id != null) SelectAdventure(args.Item.id); })"
-                    style="height: 600px;">
+                    style="height: 600px;"
+                    RowSize="DataGridRowSize.Medium">
         <ChildContent>
-            <PropertyColumn Property="@(a => a.adventurer_name)" Title="Adventurer Name" Sortable="true" Width="200"/>
+            <PropertyColumn Property="@(a => a.adventurer_name)" Title="Adventurer" Sortable="true" Width="200"/>
             <PropertyColumn Property="@(a => a.level)" Title="Level" Sortable="true"/>
             <PropertyColumn Property="@(a => a.last_saved_datetime)" Title="Saved Date" Sortable="true"/>
+            <TemplateColumn Width="60px">  
+                <FluentButton OnClick="@(async () => await AdventureDelete(context!.id))" IconEnd="@(new Icons.Regular.Size16.Delete())" />
+            </TemplateColumn>
         </ChildContent>
         <EmptyContent>
             <FluentIcon Value="@(new Icons.Filled.Size24.Crown())" Color="@Color.Accent" />&nbsp; Nothing so far, a Create a new one to get started!
@@ -60,4 +64,15 @@
     {
         Navigation.NavigateTo($"play/{adventureId}");
     }
+
+    private async Task AdventureDelete(int id)
+    {
+        bool result = await D6Service.AdventureDelete(id);
+        if (result)
+        {
+            AdventurePreviews = null;
+            await OnInitializedAsync();
+        }
+    }
+
 }

--- a/src/2d6-dungeon-web-client/Components/Shared/AdventurePicker.razor
+++ b/src/2d6-dungeon-web-client/Components/Shared/AdventurePicker.razor
@@ -21,7 +21,8 @@
             <PropertyColumn Property="@(a => a.level)" Title="Level" Sortable="true"/>
             <PropertyColumn Property="@(a => a.last_saved_datetime)" Title="Saved Date" Sortable="true"/>
             <TemplateColumn Width="60px">  
-                <FluentButton OnClick="@(async () => await AdventureDelete(context!.id))" IconEnd="@(new Icons.Regular.Size16.Delete())" />
+                <FluentButton @onclick="@(async () => await AdventureDelete(context!.id))" 
+                             IconEnd="@(new Icons.Regular.Size16.Delete())" stopPropagation="true"/>
             </TemplateColumn>
         </ChildContent>
         <EmptyContent>

--- a/src/2d6-dungeon-web-client/Components/Shared/AdventurePicker.razor
+++ b/src/2d6-dungeon-web-client/Components/Shared/AdventurePicker.razor
@@ -45,12 +45,20 @@
 
     protected override async Task OnInitializedAsync()
     {
-        try{
-            var result  = await D6Service.GetAdventurePreviews();    
-            if(result != null)
+        await LoadAdventurePreviewsAsync();
+        StateHasChanged();
+    }
+    
+    private async Task LoadAdventurePreviewsAsync()
+    {
+        try
+        {
+            var result = await D6Service.GetAdventurePreviews();
+            if (result != null)
                 AdventurePreviews = result.value.AsQueryable();
         }
-        catch(Exception ex){
+        catch (Exception ex)
+        {
             Console.WriteLine("Oops! --> " + ex.Message);
         }
     }
@@ -72,7 +80,8 @@
         if (result)
         {
             AdventurePreviews = null;
-            await OnInitializedAsync();
+            await LoadAdventurePreviewsAsync();
+            StateHasChanged();
         }
     }
 


### PR DESCRIPTION
Adds functionality to delete saved adventures and corrects the save game count calculation.

- Implements adventure deletion via a delete button in the adventure picker.
- Updates the save game count to accurately reflect the number of saved adventures by querying adventure previews.