### PR TITLE
Renames Preview classes to DTO

### DIFF
--- a/src/2d6-dungeon-service/Services/D6Service.cs
+++ b/src/2d6-dungeon-service/Services/D6Service.cs
@@ -32,15 +32,15 @@ public class D6Service
         return games?.value?.Count() ?? 0;
     }
 
-    public async Task<AdventurePreviewList?> GetAdventurePreviews()
+    public async Task<AdventureDTOList?> GetAdventurePreviews()
     {
-        return await httpClient.GetFromJsonAsync<AdventurePreviewList?>("api/adventure?$select=id,name,adventurer_id,level,last_saved_datetime");
+        return await httpClient.GetFromJsonAsync<AdventureDTOList?>("api/adventure?$select=id,name,adventurer_id,level,last_saved_datetime");
     }
 
     public async Task<Adventure> GetAdventure(int id)
     {
-        var result = await httpClient.GetFromJsonAsync<AdventurePreviewList>($"api/adventure/id/{id.ToString()}");
-        var adventurePrev = result!.value.First<AdventurePreview>();
+        var result = await httpClient.GetFromJsonAsync<AdventureDTOList>($"api/adventure/id/{id.ToString()}");
+        var adventurePrev = result!.value.First<AdventureDTO>();
 
         Adventure loadedGame = new Adventure(adventurePrev);
         if(loadedGame.Id == 0)
@@ -51,19 +51,19 @@ public class D6Service
 
     private async Task<int> AdventureCreate(Adventure game)
     {
-        AdventurePreview draftSavedGame = new AdventurePreview();
+        AdventureDTO draftSavedGame = new AdventureDTO();
         draftSavedGame.name = game.Name;
         draftSavedGame.adventurer_id = game.Adventurer.Id;
         draftSavedGame.last_saved_datetime = DateTime.Now.ToString("yyyy-MM-dd HH:mm");
 
-        var response = await httpClient.PostAsJsonAsync<AdventurePreview>($"api/adventure", draftSavedGame);
+        var response = await httpClient.PostAsJsonAsync<AdventureDTO>($"api/adventure", draftSavedGame);
         var status = response.EnsureSuccessStatusCode();
 
         if (!status.IsSuccessStatusCode)
             throw new Exception("Problem Saving the Game");
         
-        var returnedList = await response.Content.ReadFromJsonAsync<AdventurePreviewList>();
-        return returnedList!.value.First<AdventurePreview>().id;
+        var returnedList = await response.Content.ReadFromJsonAsync<AdventureDTOList>();
+        return returnedList!.value.First<AdventureDTO>().id;
     }
 
     public async Task<Adventure> AdventureSave(Adventure game)
@@ -72,10 +72,10 @@ public class D6Service
             game.Id = await AdventureCreate(game);
         }
 
-        var serializedGame = new AdventurePreview(game);
+        var serializedGame = new AdventureDTO(game);
         serializedGame.last_saved_datetime = DateTime.Now.ToString("yyyy-MM-dd HH:mm");
 
-        var response = await httpClient.PutAsJsonAsync<AdventurePreview>($"api/adventure/id/{game.Id.ToString()}", serializedGame);
+        var response = await httpClient.PutAsJsonAsync<AdventureDTO>($"api/adventure/id/{game.Id.ToString()}", serializedGame);
         var status = response.EnsureSuccessStatusCode();
 
         if (!status.IsSuccessStatusCode)
@@ -101,22 +101,22 @@ public class D6Service
     #region == Adventurer =====
     public async Task<Adventurer> GetAdventurer(int id)
     {
-        var result = await httpClient.GetFromJsonAsync<AdventurerPreviewList>($"api/adventurer/id/{id.ToString()}");
-        var adventurerPrev = result!.value.First<AdventurerPreview>();
+        var result = await httpClient.GetFromJsonAsync<AdventurerDTOList>($"api/adventurer/id/{id.ToString()}");
+        var adventurerPrev = result!.value.First<AdventurerDTO>();
 
         return new Adventurer(adventurerPrev);
     }
 
-    public async Task<AdventurerPreviewList?> GetAdventurerPreviews()
+    public async Task<AdventurerDTOList?> GetAdventurerPreviews()
     {
-        return await httpClient.GetFromJsonAsync<AdventurerPreviewList?>("api/adventurer?$select=id,name,xp,level");
+        return await httpClient.GetFromJsonAsync<AdventurerDTOList?>("api/adventurer?$select=id,name,xp,level");
     }
 
     public async Task<bool> SaveAdventurer(Adventurer player)
     {
-        var dbPlayer = new AdventurerPreview(player);
+        var dbPlayer = new AdventurerDTO(player);
 
-        var response = await httpClient.PutAsJsonAsync<AdventurerPreview>($"api/adventurer/id/{player.Id.ToString()}", dbPlayer);
+        var response = await httpClient.PutAsJsonAsync<AdventurerDTO>($"api/adventurer/id/{player.Id.ToString()}", dbPlayer);
         var status = response.EnsureSuccessStatusCode();
 
         if (status.IsSuccessStatusCode)
@@ -126,16 +126,16 @@ public class D6Service
 
     public async Task<int> AdventurerCreate(Adventurer player)
     {
-        var dbPlayer = new AdventurerPreview(player);
+        var dbPlayer = new AdventurerDTO(player);
 
-        var response = await httpClient.PostAsJsonAsync<AdventurerPreview>($"api/adventurer", dbPlayer);
+        var response = await httpClient.PostAsJsonAsync<AdventurerDTO>($"api/adventurer", dbPlayer);
         var status = response.EnsureSuccessStatusCode();
 
         if (!status.IsSuccessStatusCode)
             return 0;
         
-        var returnedList = await response.Content.ReadFromJsonAsync<AdventurerPreviewList>();
-        return returnedList!.value.First<AdventurerPreview>().id;
+        var returnedList = await response.Content.ReadFromJsonAsync<AdventurerDTOList>();
+        return returnedList!.value.First<AdventurerDTO>().id;
     }
     
     public async Task<bool> AdventurerDelete(int id)

--- a/src/2d6-dungeon-service/Services/ID6Service.cs
+++ b/src/2d6-dungeon-service/Services/ID6Service.cs
@@ -7,13 +7,13 @@ public interface ID6Service
 {
     // Adventure
     Task<int> GetSaveGameCount();
-    Task<AdventurePreviewList?> GetAdventurePreviews();
+    Task<AdventureDTOList?> GetAdventurePreviews();
     Task<Adventure> GetAdventure(int id);
     Task<Adventure> AdventureSave(Adventure game);
     Task<bool> AdventureDelete(int id);
 
     // Adventurer
-    Task<AdventurerPreviewList?> GetAdventurerPreviews();
+    Task<AdventurerDTOList?> GetAdventurerPreviews();
     Task<Adventurer> GetAdventurer(int id);
     Task<bool> SaveAdventurer(Adventurer player);
     Task<int> AdventurerCreate(Adventurer player);

--- a/src/2d6-dungeon-service/domain/Adventure.cs
+++ b/src/2d6-dungeon-service/domain/Adventure.cs
@@ -20,7 +20,7 @@ public class Adventure
         Name = $"{Adventurer.Name} adventure";
     }
 
-    public Adventure(AdventurePreview preview){
+    public Adventure(AdventureDTO preview){
 
         Adventurer = new Adventurer();
         Dungeon = new Dungeon();

--- a/src/2d6-dungeon-service/domain/AdventureDTO.cs
+++ b/src/2d6-dungeon-service/domain/AdventureDTO.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace c5m._2d6Dungeon;
 
 //lowercase to match the database
-public class AdventurePreview
+public class AdventureDTO
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int id { get; set; } = 0;
@@ -14,9 +14,9 @@ public class AdventurePreview
     public string last_saved_datetime { get; set; } = string.Empty;
     public string serialiazedObj { get; set; } = string.Empty;
 
-    public AdventurePreview(){}
+    public AdventureDTO(){}
 
-    public AdventurePreview(Adventure a)
+    public AdventureDTO(Adventure a)
     {
         id = 0;
         name = a.Name;

--- a/src/2d6-dungeon-service/domain/AdventureDTOList.cs
+++ b/src/2d6-dungeon-service/domain/AdventureDTOList.cs
@@ -1,0 +1,6 @@
+namespace c5m._2d6Dungeon;
+
+public class AdventureDTOList
+{
+	public List<AdventureDTO> value { get; set; } = new List<AdventureDTO>();
+}

--- a/src/2d6-dungeon-service/domain/AdventurePreviewList.cs
+++ b/src/2d6-dungeon-service/domain/AdventurePreviewList.cs
@@ -1,6 +1,0 @@
-namespace c5m._2d6Dungeon;
-
-public class AdventurePreviewList
-{
-	public List<AdventurePreview> value { get; set; } = new List<AdventurePreview>();
-}

--- a/src/2d6-dungeon-service/domain/Adventurer.cs
+++ b/src/2d6-dungeon-service/domain/Adventurer.cs
@@ -82,7 +82,7 @@ public class Adventurer
         Rations = 3;
     }
 
-    public Adventurer(AdventurerPreview preview){
+    public Adventurer(AdventurerDTO preview){
         if(string.IsNullOrEmpty(preview.serialiazedObj)){
             
             Id = preview.id;

--- a/src/2d6-dungeon-service/domain/AdventurerDTO.cs
+++ b/src/2d6-dungeon-service/domain/AdventurerDTO.cs
@@ -5,7 +5,7 @@ using c5m._2d6Dungeon.Game;
 namespace c5m._2d6Dungeon;
 
 //lowercase to match the database
-public class AdventurerPreview
+public class AdventurerDTO
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int id { get; set; } = 0;
@@ -14,9 +14,9 @@ public class AdventurerPreview
     public int xp { get; set; }
     public string serialiazedObj { get; set; } = string.Empty;
 
-    public AdventurerPreview(){}
+    public AdventurerDTO(){}
 
-    public AdventurerPreview(Adventurer a)
+    public AdventurerDTO(Adventurer a)
     {
         id = 0;
         name = a.Name;

--- a/src/2d6-dungeon-service/domain/AdventurerDTOList.cs
+++ b/src/2d6-dungeon-service/domain/AdventurerDTOList.cs
@@ -1,0 +1,6 @@
+﻿namespace c5m._2d6Dungeon;
+
+public class AdventurerDTOList
+{
+	public List<AdventurerDTO> value { get; set; } = new List<AdventurerDTO>();
+}

--- a/src/2d6-dungeon-service/domain/AdventurerPreviewList.cs
+++ b/src/2d6-dungeon-service/domain/AdventurerPreviewList.cs
@@ -1,6 +1,0 @@
-﻿namespace c5m._2d6Dungeon;
-
-public class AdventurerPreviewList
-{
-	public List<AdventurerPreview> value { get; set; } = new List<AdventurerPreview>();
-}

--- a/src/2d6-dungeon-web-client/Components/Shared/AdventurePicker.razor
+++ b/src/2d6-dungeon-web-client/Components/Shared/AdventurePicker.razor
@@ -12,7 +12,7 @@
     <FluentDataGrid Items="@AdventurePreviews" 
                     ShowHover="true"  
                     ResizableColumns=true 
-                    TGridItem="AdventurePreview" 
+                    TGridItem="AdventureDTO" 
                     OnRowClick="@(async (args) => { if (args.Item?.id != null) SelectAdventure(args.Item.id); })"
                     style="height: 600px;"
                     RowSize="DataGridRowSize.Medium">
@@ -37,7 +37,7 @@
 
 @code {
 
-    private IQueryable<AdventurePreview>? AdventurePreviews;
+    private IQueryable<AdventureDTO>? AdventurePreviews;
 
     [Parameter] public Adventure? ParentAdventure {get; set;}
 

--- a/src/2d6-dungeon-web-client/Components/Shared/AdventurerPicker.razor
+++ b/src/2d6-dungeon-web-client/Components/Shared/AdventurerPicker.razor
@@ -16,10 +16,10 @@ else
         <FluentLabel Typo="Typography.Body" Color="@Color.Warning">@errorMessage</FluentLabel>
 
         <FluentDataGrid 
-                        Items="@adventurersQueryable" 
-                        ShowHover="true" 
-                        TGridItem="AdventurerPreview" 
-                        OnRowClick="@((args) => SelectPlayer(args.Item!.id))"
+                Items="@adventurersQueryable" 
+                ShowHover="true" 
+                TGridItem="AdventurerDTO" 
+                OnRowClick="@((args) => SelectPlayer(args.Item!.id))"
                         RowSize="DataGridRowSize.Medium">
             <PropertyColumn Title="Name" Property="@(c => c.name)" Sortable="true"/>
             <PropertyColumn Title="XP" Property="@(c => c.xp.ToString())" Sortable="true"/>
@@ -38,8 +38,8 @@ else
 
 @code {
 
-    private AdventurerPreviewList? adventurers;
-    IQueryable<AdventurerPreview>? adventurersQueryable;
+    private AdventurerDTOList? adventurers;
+    IQueryable<AdventurerDTO>? adventurersQueryable;
 
     [Parameter] public Game.Adventurer? ParentPlayer {get; set;}
 


### PR DESCRIPTION
Renames the "Preview" classes to "DTO" to better reflect their purpose as data transfer objects. This change improves code clarity and maintainability.

fix: #60 