### PR TITLE
Prevents duplicate unique rooms on a level

### DIFF
--- a/src/2d6-dungeon-service/domain/Dungeon.cs
+++ b/src/2d6-dungeon-service/domain/Dungeon.cs
@@ -12,6 +12,9 @@ public class Dungeon
     [JsonInclude]
     private List<MappedRoom> _mappedRooms;
 
+    [JsonInclude]
+    private Dictionary<int, HashSet<int>> _usedUniqueRoomsByLevel;
+
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Dungeon"/> class.
@@ -19,6 +22,7 @@ public class Dungeon
     public Dungeon()
     {
         _mappedRooms = new List<MappedRoom>();
+        _usedUniqueRoomsByLevel = new Dictionary<int, HashSet<int>>();
     }
 
 
@@ -95,6 +99,31 @@ public class Dungeon
     {
         MappedRooms.First(r => r.Id == roomFrom.Id).YouAreHere = false;
         MappedRooms.First(r => r.Id == roomTo.Id).YouAreHere = true;
+    }
+
+    /// <summary>
+    /// Checks if a unique room has already been used on the specified floor level.
+    /// </summary>
+    /// <param name="roomId">The Room ID from the database.</param>
+    /// <param name="floorLevel">The dungeon floor level.</param>
+    /// <returns>True if the unique room has been used on this level; false otherwise.</returns>
+    public bool HasUsedUnique(int roomId, int floorLevel)
+    {
+        if (!_usedUniqueRoomsByLevel.ContainsKey(floorLevel))
+            return false;
+        return _usedUniqueRoomsByLevel[floorLevel].Contains(roomId);
+    }
+
+    /// <summary>
+    /// Marks a unique room as used on the specified floor level.
+    /// </summary>
+    /// <param name="roomId">The Room ID from the database.</param>
+    /// <param name="floorLevel">The dungeon floor level.</param>
+    public void MarkUniqueUsed(int roomId, int floorLevel)
+    {
+        if (!_usedUniqueRoomsByLevel.ContainsKey(floorLevel))
+            _usedUniqueRoomsByLevel[floorLevel] = new HashSet<int>();
+        _usedUniqueRoomsByLevel[floorLevel].Add(roomId);
     }
 
 }

--- a/src/2d6-dungeon-service/domain/NewRoomDialogData.cs
+++ b/src/2d6-dungeon-service/domain/NewRoomDialogData.cs
@@ -1,0 +1,7 @@
+namespace c5m._2d6Dungeon;
+
+public class NewRoomDialogData
+{
+    public required MappedRoom Room { get; set; }
+    public required Dungeon Dungeon { get; set; }
+}

--- a/src/2d6-dungeon-web-client/Components/Dialogues/NewRoomDialog.razor
+++ b/src/2d6-dungeon-web-client/Components/Dialogues/NewRoomDialog.razor
@@ -1,4 +1,4 @@
-﻿@implements IDialogContentComponent<MappedRoom>
+﻿@implements IDialogContentComponent<NewRoomDialogData>
 @inject IJSRuntime JSRuntime 
 @inject D6Service d6Service;
 
@@ -85,7 +85,7 @@
 @code {
 
     [Parameter]
-    public required MappedRoom Content { get; set; } = default!;
+    public required NewRoomDialogData Content { get; set; } = default!;
 
     [CascadingParameter]
     public FluentDialog? Dialog { get; set; } = default!;
@@ -105,7 +105,7 @@
     {
         gameTurn.d6Service = d6Service;
         gameTurn.Message = "Roll 2D6 to determine the dimension of the room";
-        gameTurn.CurrentRoom = Content;
+        gameTurn.CurrentRoom = Content.Room;
         
         //await MapTools.RefreshCanvas(JSRuntime);
     }
@@ -131,7 +131,7 @@
 
     private async Task OnFinishedAsync()
     {
-        Content = gameTurn.CurrentRoom!;
+        Content.Room = gameTurn.CurrentRoom!;
         await Dialog!.CloseAsync(Content);
     }
 
@@ -139,7 +139,7 @@
     {
         sizeDiceResult = DiceResult.Roll2Dice();
         
-        await gameTurn.ContinueTurn(sizeDiceResult);
+        await gameTurn.ContinueTurn(sizeDiceResult, Content.Dungeon);
         if(gameTurn.NextAction != ActionType.DoubleSizedRoom)
         {
             isSizeSet = true;
@@ -156,7 +156,7 @@
     {
         exitsDiceResult = DiceResult.Roll1Dice();
         gameTurn.NextAction = ActionType.RollForExits;
-        await gameTurn.ContinueTurn(exitsDiceResult);
+        await gameTurn.ContinueTurn(exitsDiceResult, Content.Dungeon);
         isExitsSet = true;
     }
 
@@ -164,7 +164,7 @@
     {
         DescriptionDiceResult = DiceResult.Roll2Dice();
         gameTurn.NextAction = ActionType.RollRoomDefinition;
-        await gameTurn.ContinueTurn(DescriptionDiceResult);
+        await gameTurn.ContinueTurn(DescriptionDiceResult, Content.Dungeon);
         isDescriptionSet = true;
     }
 

--- a/src/2d6-dungeon-web-client/Components/Pages/Play.razor
+++ b/src/2d6-dungeon-web-client/Components/Pages/Play.razor
@@ -252,13 +252,19 @@
 
         nextRoom = currentAdventure!.Dungeon.GetNewRoom();
 
+        var dialogData = new NewRoomDialogData 
+        { 
+            Room = nextRoom, 
+            Dungeon = currentAdventure!.Dungeon 
+        };
 
-        IDialogReference dialog = await DialogService.ShowDialogAsync<NewRoomDialog>(nextRoom, parameters);
+        IDialogReference dialog = await DialogService.ShowDialogAsync<NewRoomDialog>(dialogData, parameters);
         DialogResult? result = await dialog.Result;
 
         if (!result.Cancelled)
         {
-            nextRoom = result.Data as MappedRoom;
+            var resultData = result.Data as NewRoomDialogData;
+            nextRoom = resultData?.Room;
 
             if (nextRoom is null)
             {


### PR DESCRIPTION
Implements a mechanism to prevent the same unique room from appearing multiple times on the same dungeon level.

Introduces a `_usedUniqueRoomsByLevel` dictionary in the `Dungeon` class to track used unique room IDs per level.
The `TryResolveUniqueRoomConflict` method in `GameTurn` now re-rolls unique rooms if they've already been used on the current level, up to a maximum number of attempts.

Adds `NewRoomDialogData` to pass both the `Room` and `Dungeon` to the NewRoomDialog component.

Fixes #149
