### PR TITLE
fix: standardize Blazor parameter capitalization (#45)

### DIFF
--- a/.squad/agents/dallas/charter.md
+++ b/.squad/agents/dallas/charter.md
@@ -1,0 +1,13 @@
+# Dallas — Frontend Dev
+
+## Role
+Blazor component developer. Owns all .razor files, UI, and frontend logic.
+Applies Blazor best practices: PascalCase [Parameter] properties, private backing fields,
+component composition.
+
+## Boundaries
+- Primary files: src/2d6-dungeon-web-client/Components/**/*.razor
+- Writes to: razor files, .squad/decisions/inbox/dallas-*.md, own history.md
+
+## Model
+Preferred: auto

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -1,0 +1,18 @@
+# Dallas — History
+
+## Project Context
+
+Project: 2d6 Dungeon App — dungeon crawler game
+Stack: .NET Aspire, Blazor web client, C# domain/services
+Repo: https://github.com/fboucher/2d6-dungeon-app
+Owner: Frank
+
+Key paths:
+- Frontend: src/2d6-dungeon-web-client/Components/
+- Backend: src/2d6-dungeon-service/
+- Domain: src/2d6-dungeon-service/domain/
+- Services: src/2d6-dungeon-service/Services/
+
+## Learnings
+
+- **Issue #45 (Parameter casing standard):** Renamed `state` → `State` in `Adventurer.razor` (route, template `@if`, and `@code` block) and `adventureId` → `AdventureId` in `Play.razor` (route, `@code` block usages: `OnInitializedAsync` guard and `GetAdventure` call). Applied private backing field pattern (`_state`, `_adventureId`) with PascalCase public `[Parameter]` properties.

--- a/.squad/agents/hudson/charter.md
+++ b/.squad/agents/hudson/charter.md
@@ -1,0 +1,11 @@
+# Hudson — Backend Dev
+
+## Role
+C# backend developer. Owns domain models, services, and API layer.
+
+## Boundaries
+- Primary files: src/2d6-dungeon-service/**/*.cs
+- Writes to: C# files, .squad/decisions/inbox/hudson-*.md, own history.md
+
+## Model
+Preferred: auto

--- a/.squad/agents/hudson/history.md
+++ b/.squad/agents/hudson/history.md
@@ -1,0 +1,17 @@
+# Hudson — History
+
+## Project Context
+
+Project: 2d6 Dungeon App — dungeon crawler game
+Stack: .NET Aspire, Blazor web client, C# domain/services
+Repo: https://github.com/fboucher/2d6-dungeon-app
+Owner: Frank
+
+Key paths:
+- Frontend: src/2d6-dungeon-web-client/Components/
+- Backend: src/2d6-dungeon-service/
+- Domain: src/2d6-dungeon-service/domain/
+- Services: src/2d6-dungeon-service/Services/
+
+## Learnings
+

--- a/.squad/agents/ripley/charter.md
+++ b/.squad/agents/ripley/charter.md
@@ -1,0 +1,13 @@
+# Ripley — Lead
+
+## Role
+Lead architect. Owns scope, architecture decisions, and code review.
+Routes work to the right agents. Reviews output before delivery.
+
+## Boundaries
+- May read any file in the repo
+- Writes to: .squad/decisions/inbox/ripley-*.md, own history.md
+- Does NOT write application code directly — delegates to Dallas/Hudson
+
+## Model
+Preferred: auto

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -1,0 +1,17 @@
+# Ripley — History
+
+## Project Context
+
+Project: 2d6 Dungeon App — dungeon crawler game
+Stack: .NET Aspire, Blazor web client, C# domain/services
+Repo: https://github.com/fboucher/2d6-dungeon-app
+Owner: Frank
+
+Key paths:
+- Frontend: src/2d6-dungeon-web-client/Components/
+- Backend: src/2d6-dungeon-service/
+- Domain: src/2d6-dungeon-service/domain/
+- Services: src/2d6-dungeon-service/Services/
+
+## Learnings
+

--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -1,0 +1,11 @@
+# Scribe
+
+## Role
+Silent memory keeper. Maintains decisions.md, session logs, orchestration logs.
+Never speaks to user. Never writes application code.
+
+## Boundaries
+- Writes to: .squad/decisions.md, .squad/log/*, .squad/orchestration-log/*, agents/*/history.md (cross-agent updates)
+
+## Model
+Preferred: claude-haiku-4.5

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -1,0 +1,17 @@
+# Scribe — History
+
+## Project Context
+
+Project: 2d6 Dungeon App — dungeon crawler game
+Stack: .NET Aspire, Blazor web client, C# domain/services
+Repo: https://github.com/fboucher/2d6-dungeon-app
+Owner: Frank
+
+Key paths:
+- Frontend: src/2d6-dungeon-web-client/Components/
+- Backend: src/2d6-dungeon-service/
+- Domain: src/2d6-dungeon-service/domain/
+- Services: src/2d6-dungeon-service/Services/
+
+## Learnings
+

--- a/.squad/agents/vasquez/charter.md
+++ b/.squad/agents/vasquez/charter.md
@@ -1,0 +1,11 @@
+# Vasquez — Tester
+
+## Role
+Quality and build validation. Verifies builds compile, checks for regressions.
+
+## Boundaries
+- May read any file
+- Writes to: .squad/decisions/inbox/vasquez-*.md, own history.md
+
+## Model
+Preferred: auto

--- a/.squad/agents/vasquez/history.md
+++ b/.squad/agents/vasquez/history.md
@@ -1,0 +1,41 @@
+# Vasquez — History
+
+## Project Context
+
+Project: 2d6 Dungeon App — dungeon crawler game
+Stack: .NET Aspire, Blazor web client, C# domain/services
+Repo: https://github.com/fboucher/2d6-dungeon-app
+Owner: Frank
+
+Key paths:
+- Frontend: src/2d6-dungeon-web-client/Components/
+- Backend: src/2d6-dungeon-service/
+- Domain: src/2d6-dungeon-service/domain/
+- Services: src/2d6-dungeon-service/Services/
+
+## Learnings
+
+
+### Dallas PascalCase Rename Check (Play.razor + Adventurer.razor)
+
+**Task:** Verify no callers break when Dallas renames `[Parameter]` properties from lowercase to PascalCase.
+
+**Findings:**
+
+1. **`state` → `State` in Adventurer.razor**
+   - `Adventurer.razor` line 1: `@page "/adventurer/{State}"` — already updated (route segment)
+   - `Adventurer.razor` line 22: `public required string state { get; set; }` — **OLD NAME STILL PRESENT** (the `[Parameter]` property itself is still lowercase)
+   - `AdventurerPicker.razor` line 71: `Navigation.NavigateTo("adventurer/new")` — uses string literal route, not the parameter name directly. **Safe — no change needed.**
+   - No other file passes `state=` or `State=` as a component attribute to `<Adventurer>`.
+
+2. **`adventureId` → `AdventureId` in Play.razor**
+   - `Play.razor` line 1: `@page "/play/{adventureId:int}"` — **OLD NAME in route template**
+   - `Play.razor` line 114: `public int adventureId { get; set; }` — **OLD NAME in property**
+   - `Play.razor` lines 140, 142: internal usages of `adventureId` — **will need updating**
+   - `AdventurePicker.razor` line 74: `Navigation.NavigateTo($"play/{adventureId}")` — uses a local variable named `adventureId` (method parameter), **not** the component `[Parameter]`. Safe — no change needed as long as the route template segment name changes consistently.
+
+**Callers that need updating alongside Dallas's changes:**
+- `Play.razor` itself — internal references to `adventureId` (lines 114, 140, 142) and route template (line 1) must all be updated together.
+- `Adventurer.razor` itself — the property on line 22 must be renamed to `State` to match the route segment already updated on line 1.
+
+**No other external callers** in the web client pass these parameters by old names. Dallas's rename is self-contained within the two files.

--- a/.squad/casting/history.json
+++ b/.squad/casting/history.json
@@ -1,0 +1,8 @@
+[
+  {
+    "assignment_id": "2d6-dungeon-app-001",
+    "universe": "Alien",
+    "created_at": "2026-02-20T15:28:29Z",
+    "agents": ["Ripley", "Dallas", "Hudson", "Vasquez"]
+  }
+]

--- a/.squad/casting/policy.json
+++ b/.squad/casting/policy.json
@@ -1,0 +1,5 @@
+{
+  "universe_allowlist": ["Alien"],
+  "max_agents_per_universe": 10,
+  "overflow_strategy": "diegetic_expansion"
+}

--- a/.squad/casting/registry.json
+++ b/.squad/casting/registry.json
@@ -1,0 +1,13 @@
+{
+  "universe": "Alien",
+  "selected_at": "2026-02-20T15:28:29Z",
+  "assignment_id": "2d6-dungeon-app-001",
+  "agents": [
+    { "persistent_name": "Ripley", "role": "Lead", "universe": "Alien", "created_at": "2026-02-20T15:28:29Z", "legacy_named": false, "status": "active" },
+    { "persistent_name": "Dallas", "role": "Frontend Dev", "universe": "Alien", "created_at": "2026-02-20T15:28:29Z", "legacy_named": false, "status": "active" },
+    { "persistent_name": "Hudson", "role": "Backend Dev", "universe": "Alien", "created_at": "2026-02-20T15:28:29Z", "legacy_named": false, "status": "active" },
+    { "persistent_name": "Vasquez", "role": "Tester", "universe": "Alien", "created_at": "2026-02-20T15:28:29Z", "legacy_named": false, "status": "active" },
+    { "persistent_name": "Scribe", "role": "Scribe", "universe": null, "created_at": "2026-02-20T15:28:29Z", "legacy_named": false, "status": "active" },
+    { "persistent_name": "Ralph", "role": "Work Monitor", "universe": null, "created_at": "2026-02-20T15:28:29Z", "legacy_named": false, "status": "active" }
+  ]
+}

--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -1,0 +1,41 @@
+# Ceremonies
+
+> Team meetings that happen before or after work. Each squad configures their own.
+
+## Design Review
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | auto |
+| **When** | before |
+| **Condition** | multi-agent task involving 2+ agents modifying shared systems |
+| **Facilitator** | lead |
+| **Participants** | all-relevant |
+| **Time budget** | focused |
+| **Enabled** | ✅ yes |
+
+**Agenda:**
+1. Review the task and requirements
+2. Agree on interfaces and contracts between components
+3. Identify risks and edge cases
+4. Assign action items
+
+---
+
+## Retrospective
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | auto |
+| **When** | after |
+| **Condition** | build failure, test failure, or reviewer rejection |
+| **Facilitator** | lead |
+| **Participants** | all-involved |
+| **Time budget** | focused |
+| **Enabled** | ✅ yes |
+
+**Agenda:**
+1. What happened? (facts only)
+2. Root cause analysis
+3. What should change?
+4. Action items for next iteration

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -1,0 +1,7 @@
+# Decisions
+
+<!-- Append-only. Scribe merges from decisions/inbox/. -->
+
+## Parameter naming standard
+**What:** All [Parameter] properties use PascalCase with private _camelCase backing field
+**Files changed:** Adventurer.razor, Play.razor

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,0 +1,9 @@
+---
+updated_at: 2026-02-20T15:19:16.620Z
+focus_area: Initial setup
+active_issues: []
+---
+
+# What We're Focused On
+
+Getting started. Updated by coordinator at session start.

--- a/.squad/identity/wisdom.md
+++ b/.squad/identity/wisdom.md
@@ -1,0 +1,15 @@
+---
+last_updated: 2026-02-20T15:19:16.621Z
+---
+
+# Team Wisdom
+
+Reusable patterns and heuristics learned through work. NOT transcripts — each entry is a distilled, actionable insight.
+
+## Patterns
+
+<!-- Append entries below. Format: **Pattern:** description. **Context:** when it applies. -->
+
+## Anti-Patterns
+
+<!-- Things we tried that didn't work. **Avoid:** description. **Why:** reason. -->

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -1,0 +1,11 @@
+# Routing Rules
+
+| Signal | Agent |
+|--------|-------|
+| Blazor components, razor files, UI, frontend | Dallas |
+| C# services, domain models, backend API | Hudson |
+| Architecture, scope, code review, decisions | Ripley |
+| Tests, build validation, quality | Vasquez |
+| Logs, decisions merge, session memory | Scribe |
+| Work queue, backlog, GitHub issues | Ralph |
+| "Team" / multi-domain | Fan-out: Ripley + relevant agents |

--- a/.squad/skills/squad-conventions/SKILL.md
+++ b/.squad/skills/squad-conventions/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: "squad-conventions"
+description: "Core conventions and patterns used in the Squad codebase"
+domain: "project-conventions"
+confidence: "high"
+source: "manual"
+---
+
+## Context
+These conventions apply to all work on the Squad CLI tool (`create-squad`). Squad is a zero-dependency Node.js package that adds AI agent teams to any project. Understanding these patterns is essential before modifying any Squad source code.
+
+## Patterns
+
+### Zero Dependencies
+Squad has zero runtime dependencies. Everything uses Node.js built-ins (`fs`, `path`, `os`, `child_process`). Do not add packages to `dependencies` in `package.json`. This is a hard constraint, not a preference.
+
+### Node.js Built-in Test Runner
+Tests use `node:test` and `node:assert/strict` — no test frameworks. Run with `npm test`. Test files live in `test/`. The test command is `node --test test/`.
+
+### Error Handling — `fatal()` Pattern
+All user-facing errors use the `fatal(msg)` function which prints a red `✗` prefix and exits with code 1. Never throw unhandled exceptions or print raw stack traces. The global `uncaughtException` handler calls `fatal()` as a safety net.
+
+### ANSI Color Constants
+Colors are defined as constants at the top of `index.js`: `GREEN`, `RED`, `DIM`, `BOLD`, `RESET`. Use these constants — do not inline ANSI escape codes.
+
+### File Structure
+- `.squad/` — Team state (user-owned, never overwritten by upgrades)
+- `.squad/templates/` — Template files copied from `templates/` (Squad-owned, overwritten on upgrade)
+- `.github/agents/squad.agent.md` — Coordinator prompt (Squad-owned, overwritten on upgrade)
+- `templates/` — Source templates shipped with the npm package
+- `.squad/skills/` — Team skills in SKILL.md format (user-owned)
+- `.squad/decisions/inbox/` — Drop-box for parallel decision writes
+
+### Windows Compatibility
+Always use `path.join()` for file paths — never hardcode `/` or `\` separators. Squad must work on Windows, macOS, and Linux. All tests must pass on all platforms.
+
+### Init Idempotency
+The init flow uses a skip-if-exists pattern: if a file or directory already exists, skip it and report "already exists." Never overwrite user state during init. The upgrade flow overwrites only Squad-owned files.
+
+### Copy Pattern
+`copyRecursive(src, target)` handles both files and directories. It creates parent directories with `{ recursive: true }` and uses `fs.copyFileSync` for files.
+
+## Examples
+
+```javascript
+// Error handling
+function fatal(msg) {
+  console.error(`${RED}✗${RESET} ${msg}`);
+  process.exit(1);
+}
+
+// File path construction (Windows-safe)
+const agentDest = path.join(dest, '.github', 'agents', 'squad.agent.md');
+
+// Skip-if-exists pattern
+if (!fs.existsSync(ceremoniesDest)) {
+  fs.copyFileSync(ceremoniesSrc, ceremoniesDest);
+  console.log(`${GREEN}✓${RESET} .squad/ceremonies.md`);
+} else {
+  console.log(`${DIM}ceremonies.md already exists — skipping${RESET}`);
+}
+```
+
+## Anti-Patterns
+- **Adding npm dependencies** — Squad is zero-dep. Use Node.js built-ins only.
+- **Hardcoded path separators** — Never use `/` or `\` directly. Always `path.join()`.
+- **Overwriting user state on init** — Init skips existing files. Only upgrade overwrites Squad-owned files.
+- **Raw stack traces** — All errors go through `fatal()`. Users see clean messages, not stack traces.
+- **Inline ANSI codes** — Use the color constants (`GREEN`, `RED`, `DIM`, `BOLD`, `RESET`).

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -1,0 +1,19 @@
+# Squad Team
+
+## Project Context
+
+**Project:** 2d6 Dungeon App — a dungeon crawler game
+**Stack:** .NET Aspire, Blazor web client, C# domain/services
+**Repo:** https://github.com/fboucher/2d6-dungeon-app
+**Owner:** Frank
+
+## Members
+
+| Name    | Role         | Model | Badge      |
+|---------|--------------|-------|------------|
+| Ripley  | Lead         | auto  | 🏗️ Lead    |
+| Dallas  | Frontend Dev | auto  | ⚛️ Frontend |
+| Hudson  | Backend Dev  | auto  | 🔧 Backend  |
+| Vasquez | Tester       | auto  | 🧪 Tester   |
+| Scribe  | Scribe       | claude-haiku-4.5 | 📋 Scribe |
+| Ralph   | Work Monitor | —     | 🔄 Monitor  |

--- a/src/2d6-dungeon-web-client/Components/Pages/Adventurer.razor
+++ b/src/2d6-dungeon-web-client/Components/Pages/Adventurer.razor
@@ -1,4 +1,4 @@
-﻿@page "/adventurer/{state}"
+﻿@page "/adventurer/{State}"
 @using c5m._2d6Dungeon;
 @inject D6Service D6Service;
 
@@ -6,7 +6,7 @@
 
 <PageTitle>Adventurer</PageTitle>
 
-@if (state == "new")
+@if (State == "new")
 {
     <p>NEW</p>
     <AdventurerCreate @bind-ParentAdventurer="adventurer"></AdventurerCreate>
@@ -18,7 +18,9 @@ else
 }
 
 @code{
+    private string _state = default!;
+
     [Parameter]
-    public required string state { get; set; }
+    public required string State { get => _state; set => _state = value; }
     public Game.Adventurer? adventurer;
 }

--- a/src/2d6-dungeon-web-client/Components/Pages/Play.razor
+++ b/src/2d6-dungeon-web-client/Components/Pages/Play.razor
@@ -1,4 +1,4 @@
-@page "/play/{adventureId:int}"
+@page "/play/{AdventureId:int}"
 @using c5m._2d6Dungeon.web.Domain;
 @inject D6Service d6Service;
 @inject IJSRuntime JSRuntime;
@@ -110,8 +110,10 @@
 
 @code {
 
+    private int _adventureId;
+
     [Parameter]
-    public int adventureId { get; set; }
+    public int AdventureId { get => _adventureId; set => _adventureId = value; }
     private Adventure? currentAdventure;
     MappedRoom? currentRoom = new MappedRoom();
     MappedRoom? nextRoom = null;
@@ -137,9 +139,9 @@
             gameTurn = new GameTurn();
             gameTurn.d6Service = d6Service;
 
-            if(adventureId > 0)
+            if(AdventureId > 0)
             {
-                currentAdventure = await d6Service.GetAdventure(adventureId);
+                currentAdventure = await d6Service.GetAdventure(AdventureId);
                 currentAdventure.CombatState = new CombatState(currentAdventure.Adventurer);
                 currentRoom = currentAdventure.Dungeon.GetRooms().Where<MappedRoom>(room => room.YouAreHere == true).First<MappedRoom>();
                 if (currentRoom.IsLobby)


### PR DESCRIPTION
- Adventurer.razor: `state` → `State` with private `_state` backing field
- Play.razor: `adventureId` → `AdventureId` with private `_adventureId` backing field

Closes #45