### PR TITLE
Adds Armour Piece Selection

### DIFF
--- a/src/2d6-dungeon-web-client/Components/Dialogues/SelectArmourPiecesDialog.razor
+++ b/src/2d6-dungeon-web-client/Components/Dialogues/SelectArmourPiecesDialog.razor
@@ -1,0 +1,64 @@
+@using c5m._2d6Dungeon
+@inject D6Service D6Service
+
+@implements IDialogContentComponent<List<ArmourPiece>>
+
+@rendermode InteractiveServer
+
+<FluentStack Orientation="Orientation.Vertical" VerticalGap="12" style="min-width: 400px;">
+    @if (allPieces == null)
+    {
+        <FluentProgressRing />
+    }
+    else
+    {
+        <FluentLabel Typo="Typography.Body">
+            Select up to 3 armour pieces 
+            <span style="color: @(Content.Count > 3 ? "red" : "inherit")">
+                (@(Content.Count)/3 selected)
+            </span>
+        </FluentLabel>
+        
+        <FluentListbox TOption="ArmourPiece"
+                       Items="@allPieces"
+                       Multiple="true"
+                       SelectedOptions="@Content"
+                       SelectedOptionsChanged="@OnSelectionChanged"
+                       OptionValue="@(p => p.Id.ToString())"
+                       OptionText="@(p => $"{p.Name} | {p.Modifier} | {p.DiceSet}")"
+                       Height="200px"
+                       style="width: 100%;" />
+    }
+</FluentStack>
+
+@code {
+    [Parameter]
+    public List<ArmourPiece> Content { get; set; } = default!;
+
+    [CascadingParameter]
+    public FluentDialog Dialog { get; set; } = default!;
+
+    private List<ArmourPiece>? allPieces;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var piecesList = await D6Service.GetArmourPieces();
+        allPieces = piecesList.value;
+        UpdateDialogButtonState();
+    }
+
+    private void OnSelectionChanged(IEnumerable<ArmourPiece> selected)
+    {
+        Content.Clear();
+        Content.AddRange(selected);
+        UpdateDialogButtonState();
+    }
+
+    private void UpdateDialogButtonState()
+    {
+        if (Dialog != null)
+        {
+            Dialog.TogglePrimaryActionButton(Content.Count <= 3);
+        }
+    }
+}

--- a/src/2d6-dungeon-web-client/Components/Shared/AdventurerCard.razor
+++ b/src/2d6-dungeon-web-client/Components/Shared/AdventurerCard.razor
@@ -1,4 +1,4 @@
-﻿@using c5m._2d6Dungeon;
+@using c5m._2d6Dungeon;
 @inject D6Service D6Service;
 @inject IDialogService DialogService;
 
@@ -91,7 +91,7 @@
         </FluentCard>
 
         <FluentCard MinimalStyle="true" Width="90%">
-            <ArmourPieces armourPiece="@Player.ArmourPieces" />
+            <ArmourPieces armourPiece="@Player.ArmourPieces" OnArmourPiecesChanged="@HandleArmourPiecesChanged" />
         </FluentCard>
 
         <FluentCard MinimalStyle="true" Width="90%" >
@@ -375,6 +375,12 @@
     {
         @* Player.MagicPotions ??= new List<MagicPotion>();
         Player.MagicPotions.Add(potion); *@
+        await PlayerChanged.InvokeAsync(Player);
+        StateHasChanged();
+    }
+
+    private async Task HandleArmourPiecesChanged(List<ArmourPiece> pieces)
+    {
         await PlayerChanged.InvokeAsync(Player);
         StateHasChanged();
     }

--- a/src/2d6-dungeon-web-client/Components/Shared/ArmourPieces.razor
+++ b/src/2d6-dungeon-web-client/Components/Shared/ArmourPieces.razor
@@ -1,5 +1,10 @@
 @rendermode InteractiveServer
+@inject IDialogService DialogService
 
+<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+    <div class="sheetTitle"><b>ARMOUR PIECES</b></div>
+    <FluentButton Appearance="Appearance.Accent" OnClick="@OpenEditArmourPiecesDialog" IconStart="@(new Icons.Regular.Size16.ShieldSettings())" ToolTip="Edit Armour Pieces" />
+</div>
 @if(armourPiece != null){
     <FluentDataGrid Items="@pieces" style="width: 100%;" MultiLine="true">
         <PropertyColumn Title="ARMOUR PIECE" Property="@(a => a.Name)" Sortable="false" />
@@ -24,6 +29,9 @@
 
     [Parameter]
     public List<ArmourPiece>? armourPiece { get; set; }
+
+    [Parameter]
+    public EventCallback<List<ArmourPiece>> OnArmourPiecesChanged { get; set; }
     
     IQueryable<ArmourPiece>? pieces;
     
@@ -32,4 +40,32 @@
         pieces = armourPiece?.AsQueryable();
     }
 
+    private async Task OpenEditArmourPiecesDialog()
+    {
+        var currentPieces = armourPiece != null ? new List<ArmourPiece>(armourPiece) : new List<ArmourPiece>();
+        
+        var dialog = await DialogService.ShowDialogAsync<SelectArmourPiecesDialog>(
+            currentPieces,
+            new DialogParameters()
+            {
+                Title = "Edit Armour Pieces",
+                PrimaryAction = "Save",
+                PrimaryActionEnabled = currentPieces.Count <= 3,
+                SecondaryAction = "Cancel",
+                Width = "450px",
+                Modal = true,
+            });
+
+        var result = await dialog.Result;
+        if (!result.Cancelled && result.Data is List<ArmourPiece> selectedPieces)
+        {
+            if (armourPiece != null)
+            {
+                armourPiece.Clear();
+                armourPiece.AddRange(selectedPieces);
+            }
+            pieces = armourPiece?.AsQueryable();
+            await OnArmourPiecesChanged.InvokeAsync(armourPiece);
+        }
+    }
 }


### PR DESCRIPTION
Introduces a new dialog for selecting and updating an adventurer's armour pieces:
- The 'ArmourPieces' component now features an 'Edit' button, which launches the selection dialog.
- Users can choose up to three armour pieces from a full list.
- The dialog dynamically controls the 'Save' button's state, enabling it only when a valid number of pieces (0-3) is selected.
- Changes are reflected on the adventurer card, enhancing character equipment management.

Relates to #186