### PR TITLE
feat: use all door types from room definition (#191)

### DIFF
--- a/src/2d6-dungeon-service/domain/GameTurn.cs
+++ b/src/2d6-dungeon-service/domain/GameTurn.cs
@@ -153,6 +153,7 @@ public class GameTurn
 
         CurrentRoom!.Description = room.description;
         CurrentRoom!.Encounter = room.encounter;
+        CurrentRoom!.ExitsType = room.exits;
         //NextAction = ActionType.RollForExits;
         Message = $"Go to the sumary to see all the details of the room.";
     }
@@ -182,6 +183,8 @@ public class GameTurn
         if(currentRoom.Exits == null)
                 currentRoom.Exits = new Dictionary<Direction,Exit>();
 
+        string doorType = ResolveDoorType(currentRoom.ExitsType, rnd);
+
         foreach(var wall in wallsWithExits.ToList())
         {
             var aDoor = new Exit();
@@ -198,8 +201,41 @@ public class GameTurn
             aDoor.Direction = wall;
             aDoor.PositionOnWall = rnd.Next(1, maxPos);
             aDoor.Lockable = false;
+            aDoor.ExitType = doorType;
             currentRoom.Exits.Add(wall, aDoor); 
         }
+    }
+
+    private static readonly string[] DoorTypes = new[]
+    {
+        "archway", "wooden", "metal", "reinforced", "curtain", "portcullis", "stone_slab"
+    };
+
+    private static string ResolveDoorType(string? exitsType, Random rnd)
+    {
+        if (string.IsNullOrWhiteSpace(exitsType))
+        {
+            return "archway";
+        }
+
+        string normalized = exitsType.Trim().ToLowerInvariant();
+
+        if (normalized == "random")
+        {
+            return DoorTypes[rnd.Next(DoorTypes.Length)];
+        }
+
+        return normalized switch
+        {
+            "archways" or "archway" => "archway",
+            "wooden doors" or "wooden" => "wooden",
+            "metal doors" or "metal" => "metal",
+            "reinforced doors" or "reinforced" => "reinforced",
+            "curtains" or "curtain" => "curtain",
+            "portcullis" or "portcullises" => "portcullis",
+            "stone slab" or "stone_slab" or "stoneslab" => "stone_slab",
+            _ => "archway"
+        };
     }
 
     public static Direction GetOppositeDirection(Direction direction)

--- a/src/2d6-dungeon-service/domain/MappedRoom.cs
+++ b/src/2d6-dungeon-service/domain/MappedRoom.cs
@@ -13,6 +13,7 @@ public class MappedRoom
     public bool IsLobby { get; set; } = false;
     public string? Description { get; set; }
     public string? Encounter { get; set; }
+    public string? ExitsType { get; set; }
     public bool YouAreHere { get; set; } = false;
 
 

--- a/src/2d6-dungeon-web-client/Components/Pages/Play.razor
+++ b/src/2d6-dungeon-web-client/Components/Pages/Play.razor
@@ -54,7 +54,53 @@
 
             <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="10">
 
-                <canvas id="dotCanvas" style="width: 800px; height: 800px;"></canvas>
+                <div style="position: relative;">
+                    <canvas id="dotCanvas" style="width: 800px; height: 800px;"></canvas>
+
+                    <!-- Legend Floating Button -->
+                    <button class="legend-floating-btn" @onclick="ToggleLegendPanel" title="Show door legend">
+                        Legend
+                    </button>
+
+                    <!-- Legend Panel -->
+                    @if (isLegendVisible)
+                    {
+                        <div class="legend-panel">
+                            <div class="legend-panel-header">
+                                <span class="legend-panel-title">Door Types</span>
+                                <button class="legend-panel-close" @onclick="ToggleLegendPanel" title="Close legend">&#10005;</button>
+                            </div>
+                            <div class="legend-item">
+                                <canvas id="legend-archway" class="legend-canvas" width="80" height="80"></canvas>
+                                <span class="legend-label">Archway</span>
+                            </div>
+                            <div class="legend-item">
+                                <canvas id="legend-wooden" class="legend-canvas" width="80" height="80"></canvas>
+                                <span class="legend-label">Wooden Door</span>
+                            </div>
+                            <div class="legend-item">
+                                <canvas id="legend-metal" class="legend-canvas" width="80" height="80"></canvas>
+                                <span class="legend-label">Metal Door</span>
+                            </div>
+                            <div class="legend-item">
+                                <canvas id="legend-reinforced" class="legend-canvas" width="80" height="80"></canvas>
+                                <span class="legend-label">Reinforced Door</span>
+                            </div>
+                            <div class="legend-item">
+                                <canvas id="legend-curtain" class="legend-canvas" width="80" height="80"></canvas>
+                                <span class="legend-label">Curtain</span>
+                            </div>
+                            <div class="legend-item">
+                                <canvas id="legend-portcullis" class="legend-canvas" width="80" height="80"></canvas>
+                                <span class="legend-label">Portcullis</span>
+                            </div>
+                            <div class="legend-item">
+                                <canvas id="legend-stone_slab" class="legend-canvas" width="80" height="80"></canvas>
+                                <span class="legend-label">Stone Slab</span>
+                            </div>
+                        </div>
+                    }
+                </div>
 
                 <div id="maps-menu" style="position: sticky; top: 20px; align-self: flex-start;">
                     <FluentStack Orientation="Orientation.Vertical" VerticalGap="10" >
@@ -159,6 +205,27 @@
         ? "border:3px solid var(--accent-fill-rest); box-shadow:0 0 8px var(--accent-fill-rest);"
         : null;
 
+    private bool isLegendVisible = false;
+
+    private async Task ToggleLegendPanel()
+    {
+        isLegendVisible = !isLegendVisible;
+        if (isLegendVisible)
+        {
+            // Allow DOM to render canvases before drawing
+            await Task.Yield();
+            await DrawLegendIcons();
+        }
+    }
+
+    private async Task DrawLegendIcons()
+    {
+        string[] doorTypes = new[] { "archway", "wooden", "metal", "reinforced", "curtain", "portcullis", "stone_slab" };
+        foreach (var type in doorTypes)
+        {
+            await JSRuntime.InvokeVoidAsync("drawLegendDoor", $"legend-{type}", type);
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/2d6-dungeon-web-client/Domain/MapTools.cs
+++ b/src/2d6-dungeon-web-client/Domain/MapTools.cs
@@ -74,7 +74,7 @@ public static class MapTools
                 isMain = currentRoom.IsLobby;
             }
 
-            await js.InvokeVoidAsync("DrawDoor", x, y, orientation, isMain, null, null, youAreHere);
+            await js.InvokeVoidAsync("DrawDoor", x, y, orientation, isMain, door.Value.ExitType, door.Value.IsLocked, youAreHere);
         }
 
 

--- a/src/2d6-dungeon-web-client/wwwroot/app.css
+++ b/src/2d6-dungeon-web-client/wwwroot/app.css
@@ -318,6 +318,115 @@ body.dungeon-theme fluent-button {
     }
 }
 
+/* ============================================
+   MAP LEGEND PANEL
+   ============================================ */
+.legend-floating-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 100;
+    background: var(--neutral-layer-3, #5a4738);
+    color: var(--neutral-foreground-rest, #f5e6d3);
+    border: 2px solid var(--accent-fill-rest, #8b6f47);
+    border-radius: 8px;
+    padding: 6px 12px;
+    cursor: pointer;
+    font-family: var(--body-font, "Segoe UI", sans-serif);
+    font-size: 14px;
+    font-weight: 600;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+    transition: background 0.2s, transform 0.1s;
+}
+
+.legend-floating-btn:hover {
+    background: var(--accent-fill-hover, #a0845a);
+    transform: scale(1.05);
+}
+
+.legend-panel {
+    position: absolute;
+    top: 50px;
+    right: 10px;
+    z-index: 101;
+    width: 220px;
+    background: linear-gradient(135deg, #E8DCC4 0%, #C4B59A 100%);
+    border: 3px solid #2A2420;
+    border-radius: 10px;
+    padding: 16px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+    font-family: var(--body-font, "Segoe UI", sans-serif);
+    color: #2A2420;
+}
+
+.legend-panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+    border-bottom: 2px solid #2A2420;
+    padding-bottom: 8px;
+}
+
+.legend-panel-title {
+    font-size: 16px;
+    font-weight: 700;
+    color: #2A2420;
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.legend-panel-close {
+    background: none;
+    border: none;
+    font-size: 20px;
+    font-weight: bold;
+    color: #2A2420;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0 4px;
+    transition: color 0.2s, transform 0.1s;
+}
+
+.legend-panel-close:hover {
+    color: #8B2500;
+    transform: scale(1.2);
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 10px;
+    padding: 4px 6px;
+    border-radius: 6px;
+    transition: background 0.2s;
+}
+
+.legend-item:hover {
+    background: rgba(42, 36, 32, 0.08);
+}
+
+.legend-item:last-child {
+    margin-bottom: 0;
+}
+
+.legend-canvas {
+    width: 40px;
+    height: 40px;
+    border: 1px solid #2A2420;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+
+.legend-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: #2A2420;
+    text-transform: capitalize;
+}
+
 @media (max-width: 600px) {
     .header-gutters {
         margin: 0.5rem 3rem 0.5rem 1.5rem !important;

--- a/src/2d6-dungeon-web-client/wwwroot/scripts/canvasTools.js
+++ b/src/2d6-dungeon-web-client/wwwroot/scripts/canvasTools.js
@@ -721,4 +721,41 @@ if (document.readyState === 'loading') {
   setupKeyboardPanning();
 }
 
+// ============================================
+// LEGEND PANEL - Draw door icons for legend
+// ============================================
+function drawLegendDoor(canvasId, doorType) {
+  const legendCanvas = document.getElementById(canvasId);
+  if (!legendCanvas) return;
+
+  const size = legendCanvas.width;
+  const ctx = legendCanvas.getContext('2d');
+
+  // Clear canvas
+  ctx.clearRect(0, 0, size, size);
+
+  // Save original context
+  const savedContext = context;
+  context = ctx;
+
+  // Draw parchment background cell
+  ctx.fillStyle = MapTheme.STONE_LIGHT;
+  ctx.fillRect(0, 0, size, size);
+
+  // Draw wall frame (like a single grid cell)
+  ctx.strokeStyle = MapTheme.WALL_OUTER;
+  ctx.lineWidth = 3;
+  ctx.strokeRect(1, 1, size - 2, size - 2);
+
+  // Draw door symbol in the center
+  const centerX = size / 2;
+  const centerY = size / 2;
+  const doorColor = DoorColors.UNLOCKED;
+
+  DrawDoorType(centerX, centerY, size, size, 'H', doorType, doorColor, false);
+
+  // Restore original context
+  context = savedContext;
+}
+
 

--- a/src/2d6-dungeon-web-client/wwwroot/scripts/canvasTools.js
+++ b/src/2d6-dungeon-web-client/wwwroot/scripts/canvasTools.js
@@ -748,11 +748,10 @@ function drawLegendDoor(canvasId, doorType) {
   ctx.strokeRect(1, 1, size - 2, size - 2);
 
   // Draw door symbol in the center
-  const centerX = size / 2;
-  const centerY = size / 2;
+  // DrawDoorType expects top-left (posX, posY); it computes center internally
   const doorColor = DoorColors.UNLOCKED;
 
-  DrawDoorType(centerX, centerY, size, size, 'H', doorType, doorColor, false);
+  DrawDoorType(0, 0, size, size, 'H', doorType, doorColor, false);
 
   // Restore original context
   context = savedContext;

--- a/src/2d6-dungeon-web-client/wwwroot/scripts/canvasTools.js
+++ b/src/2d6-dungeon-web-client/wwwroot/scripts/canvasTools.js
@@ -758,4 +758,7 @@ function drawLegendDoor(canvasId, doorType) {
   context = savedContext;
 }
 
+// Explicitly expose drawLegendDoor on window for Blazor JS interop
+window.drawLegendDoor = drawLegendDoor;
+
 


### PR DESCRIPTION
Implements door type assignment based on the room definition `exits` property.

### Changes
- Added `ExitsType` property to `MappedRoom` to store the room's door type definition
- `RollRoomDefinition` now captures `room.exits` from the database onto the current room
- `AssignExits` resolves the door type string and sets `ExitType` on each exit:
  - Supports: Archways, Wooden Doors, Metal Doors, Reinforced Doors, Curtains, Portcullis, Stone Slab
  - `RANDOM` picks from all available types
  - Defaults to `archway` when undefined
- `MapTools.DrawDoors` passes `ExitType` and `IsLocked` to the JS `DrawDoor` function

### Testing
- Build succeeds with 0 warnings / 0 errors
- Ready for play-testing to verify door types render correctly on the canvas map

Closes #191