### PR TITLE
feat: A Door Can be locked (issue #148)

### DIFF
--- a/src/2d6-dungeon-service/domain/Dungeon.cs
+++ b/src/2d6-dungeon-service/domain/Dungeon.cs
@@ -97,8 +97,14 @@ public class Dungeon
 
     public void ChangeRoom(MappedRoom roomFrom, MappedRoom roomTo)
     {
-        MappedRooms.First(r => r.Id == roomFrom.Id).YouAreHere = false;
-        MappedRooms.First(r => r.Id == roomTo.Id).YouAreHere = true;
+        var from = MappedRooms.FirstOrDefault(r => r.Id == roomFrom.Id);
+        var to = MappedRooms.FirstOrDefault(r => r.Id == roomTo.Id);
+
+        if (from != null)
+            from.YouAreHere = false;
+
+        if (to != null)
+            to.YouAreHere = true;
     }
 
     /// <summary>

--- a/src/2d6-dungeon-service/domain/GameTurn.cs
+++ b/src/2d6-dungeon-service/domain/GameTurn.cs
@@ -25,6 +25,8 @@ public class GameTurn
                 break;
             case(ActionType.RollForExits): RollForExits(dResult);
                 break;
+            case(ActionType.RollForLocks): RollForLocks(dResult);
+                break;
             case(ActionType.RollRoomDefinition): 
                 int area = CurrentRoom!.Width * CurrentRoom.Height;
                 await RollRoomDefinition(area, dResult, dungeon);
@@ -116,9 +118,6 @@ public class GameTurn
                 break;
         }
 
-
-
-
         if(CurrentRoom.IsCorridor)
         {
             NextAction = ActionType.EndOfTurn;
@@ -129,8 +128,26 @@ public class GameTurn
             NextAction = ActionType.Encounter;
             Message = $"There {CurrentRoom.ExitsCount} other exits in this room.";
         }
+    }
 
+    private void RollForLocks(DiceResult dResult)
+    {
+        if(CurrentRoom == null){
+            throw new Exception("Lost the info about the current room. PLease start the turn again.");
+        }
+
+        CurrentRoom.LockRoll = dResult.PrimaryDice;
+        NextAction = ActionType.Encounter;
         
+        string lockMessage = dResult.PrimaryDice switch
+        {
+            6 => "All doors in this room are locked!",
+            5 => "Reinforced doors are locked.",
+            4 => "Metal doors are locked.",
+            _ => "No doors are locked."
+        };
+        
+        Message = lockMessage;
     }
 
     private void DraftCurrentRoom(DiceResult dResult){
@@ -171,7 +188,7 @@ public class GameTurn
         currentRoom.Exits.Add(entranceWall, mainDoor);
     }
 
-    public static void AssignExits(MappedRoom currentRoom, Direction entrance)
+    public static void AssignExits(MappedRoom currentRoom, Direction entrance, int? lockRoll = null)
     {
         int seed = DateTime.UtcNow.Millisecond;
         Random rnd = new Random(seed);
@@ -200,10 +217,24 @@ public class GameTurn
             }
             aDoor.Direction = wall;
             aDoor.PositionOnWall = rnd.Next(1, maxPos);
-            aDoor.Lockable = false;
+            aDoor.Lockable = true;
+            aDoor.IsLocked = IsDoorLocked(doorType, lockRoll);
             aDoor.ExitType = doorType;
             currentRoom.Exits.Add(wall, aDoor); 
         }
+    }
+
+    private static bool IsDoorLocked(string doorType, int? lockRoll)
+    {
+        if (lockRoll == null) return false;
+
+        return lockRoll switch
+        {
+            6 => true,
+            5 => doorType == "reinforced",
+            4 => doorType == "metal",
+            _ => false
+        };
     }
 
     private static readonly string[] DoorTypes = new[]
@@ -318,6 +349,7 @@ public enum ActionType
     DrawRoom,
     EndOfTurn,
     RollRoomDefinition,
+    RollForLocks,
     Encounter,
     DungeonStarted
 }

--- a/src/2d6-dungeon-service/domain/MappedRoom.cs
+++ b/src/2d6-dungeon-service/domain/MappedRoom.cs
@@ -14,6 +14,7 @@ public class MappedRoom
     public string? Description { get; set; }
     public string? Encounter { get; set; }
     public string? ExitsType { get; set; }
+    public int? LockRoll { get; set; }
     public bool YouAreHere { get; set; } = false;
 
 

--- a/src/2d6-dungeon-web-client/Components/Dialogues/NewRoomDialog.razor
+++ b/src/2d6-dungeon-web-client/Components/Dialogues/NewRoomDialog.razor
@@ -68,15 +68,38 @@
                 </div>
             </FluentStack>
         </FluentWizardStep>
+        <FluentWizardStep Label="Locks"
+                          Summary="Check for locked doors"
+                          OnChange="@OnStepChange"
+                          Disabled="@(isCorridor || hasNoExits)">
+            <FluentStack Orientation="Orientation.Vertical">
+                @if (hasNoExits)
+                {
+                    <p>There are no doors in this room, so there's nothing to lock.</p>
+                }
+                else
+                {
+                    <p>@(gameTurn!.Message ?? string.Empty)</p>
+                    <FluentButton @onclick=RollDiceForLocks Appearance="Appearance.Accent" disabled="@(isLocksSet)">Roll 1D6</FluentButton>
+
+                    <div style="padding:20px;">
+                        <span style="@(locksDiceResult.PrimaryDice == 0 ? "display:none" : "")">
+                            <Dice face="@locksDiceResult.PrimaryDice" size="Dice.DiceSize.regular" color="Dice.DiceColor.red" Animate="true"></Dice>
+                        </span>
+                    </div>
+                }
+            </FluentStack>
+        </FluentWizardStep>
         <FluentWizardStep   Label="Summary"
                             Summary="Summary of the new room"
                             OnChange="@OnStepChange">
             <div style="padding:20px;">
-            @if(isSizeSet && isExitsSet && isDescriptionSet)
+            @if(isSizeSet && isExitsSet && isDescriptionSet && isLocksSet)
             {
                 <p>The room is @gameTurn.CurrentRoom!.Width by @gameTurn.CurrentRoom.Height</p>
                 <p>Excluding the door you used to ge in, there @gameTurn.CurrentRoom.ExitsCount other door(s)</p>
                 <p>@gameTurn.CurrentRoom.Description</p>
+                <p>@(gameTurn!.Message ?? string.Empty)</p>
             }
             </div>
         </FluentWizardStep>
@@ -97,10 +120,13 @@
     private DiceResult sizeDiceResult = new DiceResult { PrimaryDice = 0, SecondaryDice = 0 };
     private DiceResult exitsDiceResult = new DiceResult { PrimaryDice = 0, SecondaryDice = 0 };
     private DiceResult DescriptionDiceResult = new DiceResult { PrimaryDice = 0, SecondaryDice = 0 };
+    private DiceResult locksDiceResult = new DiceResult { PrimaryDice = 0, SecondaryDice = 0 };
     private bool isSizeSet = false;
     private bool isExitsSet = false;
     private bool isDescriptionSet = false;
+    private bool isLocksSet = false;
     private bool isCorridor = false;
+    private bool hasNoExits = false;
     
     // Dice refs for doubles celebration
     private Dice? sizeDiceA;
@@ -131,6 +157,9 @@
                 gameTurn.Message = "Roll 2D6 to know what's in that room";
                 break;
             case 3:
+                gameTurn.Message = "Roll 1D6 to check for locked doors";
+                break;
+            case 4:
                 Dialog!.TogglePrimaryActionButton(true);
                 break;
         }
@@ -154,6 +183,7 @@
             {
                 gameTurn.CurrentRoom.Description = "You found a corridor";
                 isDescriptionSet = true;
+                isLocksSet = true;
                 isCorridor = true;
             }
         }
@@ -172,6 +202,13 @@
         gameTurn.NextAction = ActionType.RollForExits;
         await gameTurn.ContinueTurn(exitsDiceResult, Content.Dungeon);
         isExitsSet = true;
+
+        if (gameTurn.CurrentRoom!.ExitsCount == 0)
+        {
+            hasNoExits = true;
+            isLocksSet = true;
+            gameTurn.Message = "There are no doors in this room to lock.";
+        }
     }
 
     private async Task RollDiceForDescription()
@@ -187,6 +224,14 @@
             await Task.Delay(650);
             await descDiceA.CelebrateDoublesWith(descDiceB.DiceId);
         }
+    }
+
+    private async Task RollDiceForLocks()
+    {
+        locksDiceResult = DiceResult.Roll1Dice();
+        gameTurn.NextAction = ActionType.RollForLocks;
+        await gameTurn.ContinueTurn(locksDiceResult, Content.Dungeon);
+        isLocksSet = true;
     }
 
     private async Task SaveAsync()

--- a/src/2d6-dungeon-web-client/Components/Dialogues/SelectDoorDialog.razor
+++ b/src/2d6-dungeon-web-client/Components/Dialogues/SelectDoorDialog.razor
@@ -8,13 +8,13 @@
 {
     <FluentStack Orientation="Orientation.Vertical" HorizontalAlignment="HorizontalAlignment.Center">
         <span>Which door do you want to open?</span>
-        <FluentButton Disabled=@(!isDoorN) OnClick="@(() => ToggleDialogPrimaryActionButton(Direction.North))" IconStart="@iconDoorN">Door to the North</FluentButton>
+        <FluentButton Disabled=@(!isDoorN || isLockedDoorN) OnClick="@(() => ToggleDialogPrimaryActionButton(Direction.North))" IconStart="@iconDoorN">Door to the North</FluentButton>
         <FluentStack Orientation="Orientation.Horizontal"  HorizontalAlignment="HorizontalAlignment.Center">
-            <FluentButton Disabled=@(!isDoorW) OnClick="@(() => ToggleDialogPrimaryActionButton(Direction.West))" IconStart="@iconDoorW">Door to the West</FluentButton>
+            <FluentButton Disabled=@(!isDoorW || isLockedDoorW) OnClick="@(() => ToggleDialogPrimaryActionButton(Direction.West))" IconStart="@iconDoorW">Door to the West</FluentButton>
             <FluentIcon Value="@(new Icons.Regular.Size32.Globe())" />
-            <FluentButton Disabled=@(!isDoorE) OnClick="@(() => ToggleDialogPrimaryActionButton(Direction.East))" IconStart="@iconDoorE">Door to the East</FluentButton>
+            <FluentButton Disabled=@(!isDoorE || isLockedDoorE) OnClick="@(() => ToggleDialogPrimaryActionButton(Direction.East))" IconStart="@iconDoorE">Door to the East</FluentButton>
         </FluentStack>
-        <FluentButton Disabled=@(!isDoorS) OnClick="@(() => ToggleDialogPrimaryActionButton(Direction.South))" IconStart="@iconDoorS">Door to the South</FluentButton>
+        <FluentButton Disabled=@(!isDoorS || isLockedDoorS) OnClick="@(() => ToggleDialogPrimaryActionButton(Direction.South))" IconStart="@iconDoorS">Door to the South</FluentButton>
     </FluentStack>
 }
 
@@ -30,6 +30,11 @@
     private bool isDoorS = false;
     private bool isDoorW = false;
     private bool isDoorE = false;
+
+    private bool isLockedDoorN = false;
+    private bool isLockedDoorS = false;
+    private bool isLockedDoorW = false;
+    private bool isLockedDoorE = false;
 
     private Icon iconDoorN = new Icons.Regular.Size20.Door();
     private Icon iconDoorS = new Icons.Regular.Size20.Door();
@@ -51,18 +56,22 @@
             switch(door.Key){
                 case(Direction.North): 
                     isDoorN = true;
+                    isLockedDoorN = door.Value.IsLocked;
                     iconDoorN = (door.Value.IsLocked) ? doorLockedIcon: doorIcon;
                     break;
                 case(Direction.East): 
                     isDoorE = true;
+                    isLockedDoorE = door.Value.IsLocked;
                     iconDoorE = (door.Value.IsLocked) ? doorLockedIcon: doorIcon;
                     break;
                 case(Direction.South): 
                     isDoorS = true;
+                    isLockedDoorS = door.Value.IsLocked;
                     iconDoorS = (door.Value.IsLocked) ? doorLockedIcon: doorIcon;
                     break;
                 case(Direction.West): 
                     isDoorW = true;
+                    isLockedDoorW = door.Value.IsLocked;
                     iconDoorW = (door.Value.IsLocked) ? doorLockedIcon: doorIcon;
                     break;
             }

--- a/src/2d6-dungeon-web-client/Components/Pages/Play.razor
+++ b/src/2d6-dungeon-web-client/Components/Pages/Play.razor
@@ -278,10 +278,21 @@
         if(directionTo is not null){
             var exit = currentRoom!.Exits![directionTo.Value];
 
+            if (exit.IsLocked)
+            {
+                ToastService.ShowToast(ToastIntent.Warning, "This door is locked! You need to find a way to unlock it.");
+                return;
+            }
+
             if (exit.TargetRoomId > 0)
             {
                 var destinationRoom = currentAdventure!.Dungeon.GetRoom(exit.TargetRoomId.Value);
-                currentAdventure!.Dungeon.ChangeRoom(currentRoom!, destinationRoom!);
+                if (destinationRoom is null)
+                {
+                    ToastService.ShowToast(ToastIntent.Warning, "That room hasn't been added to the dungeon yet. Position it and click Add Room to Map first.");
+                    return;
+                }
+                currentAdventure!.Dungeon.ChangeRoom(currentRoom!, destinationRoom);
                 currentRoom = destinationRoom;
                 gameTurnInstructions = "You already visited that room, Pick another door!";
                 await RefreshCanvas();
@@ -374,7 +385,7 @@
 
             @* Char entranceWall = directionFrom.ToString()[0]; *@
             GameTurn.SetDungeonEntranceDoor(nextRoom!, directionFrom, currentRoom!.Id);
-            GameTurn.AssignExits(nextRoom!, directionFrom);
+            GameTurn.AssignExits(nextRoom!, directionFrom, nextRoom.LockRoll);
 
             var (originX, originY) = MapTools.GetRoomOriginForDoorGridPosition(nextRoom!, directionFrom, entranceDoorX, entranceDoorY);
             nextRoom.CoordX = originX;


### PR DESCRIPTION
Implements locked door logic per issue #148.

### Changes
- **NewRoomDialog**: Added a "Locks" wizard step where the user rolls 1D6 after determining exits.
- **GameTurn**: Added  action and  helper. Lock rules:
  -  → All doors locked
  -  → Reinforced doors locked
  -  → Metal doors locked
  -  → No doors locked
- **MappedRoom**: Added  property.
- **SelectDoorDialog**: Locked doors are now disabled and show a locked icon.
- **Play.razor**: Passes  to ; also fixed a pre-existing  when navigating to a room that hasn't been added to the dungeon yet.
- **Locks step is skipped** when the room is a corridor or has 0 exits.

Builds cleanly with 0 warnings / 0 errors.